### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/pkg/health/ethereum/execution_rpc.go
+++ b/pkg/health/ethereum/execution_rpc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/kurtosis-tech/stacktrace"
 	log "github.com/sirupsen/logrus"
+	"slices"
 	"time"
 )
 
@@ -116,13 +117,7 @@ func (c *ExecClientRPC) GetLatestBlockBy(ctx context.Context, blockType string) 
 			"unknown block",             //reth
 		}
 
-		noFinalBlockFound := false
-		for _, msg := range notFinalizingErrors {
-			if err.Error() == msg {
-				noFinalBlockFound = true
-				break
-			}
-		}
+		noFinalBlockFound := slices.Contains(notFinalizingErrors, err.Error())
 
 		if noFinalBlockFound {
 			choice = &ClientForkChoice{


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.